### PR TITLE
[12.0] pos_keyboard : barcode scanner conflict

### DIFF
--- a/pos_keyboard/static/src/js/pos.js
+++ b/pos_keyboard/static/src/js/pos.js
@@ -46,12 +46,13 @@ odoo.define('pos_keyboard.pos', function (require) {
 
     PopupWidget.include({
         keypad_action: function(data){
+            var barcode_scanned = this.options.barcode
             var type = this.pos.keypad.type;
             if (data.type === type.numchar){
                 this.click_keyboard(data.val);
             } else if (data.type === type.backspace){
                 this.click_keyboard('BACKSPACE');
-            } else if (data.type === type.enter){
+            } else if (data.type === type.enter && !barcode_scanned){
                 // some pop-ups might throw an error due to lack of some income data
                 try {
                     return this.click_confirm();


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=5060&view_type=form&model=project.task&action=475&active_id=117)
When scanning a unknown barcode with a scanner, an error barcode popup is shown. 
Since the usual default configuration of a scanner is to end each scanned barcode with a carriage return, the popup is immediately closed since `pos_keyboard` interpret it as an 'enter' key.

This commit is a workaround to prevent the closing of the popup. To close it with a keyboard, the user should press 'escape' key or use the mouse.